### PR TITLE
Made the quote a block quote

### DIFF
--- a/P06-Building-The-End-Game/content.md
+++ b/P06-Building-The-End-Game/content.md
@@ -73,7 +73,9 @@ Add some custom CSS to make your cookie clicker beautiful.
 
 # Onward?
 
-![Alice in Wonderland](assets/alice.jpeg "Alice in Wonderland")  
+![Alice in Wonderland](assets/alice.jpeg "Alice in Wonderland") 
+
+<blockquote>
 “Would you tell me, please, which way I ought to go from here?"    
 "That depends a good deal on where you want to get to," said the Cat.  
 "I don't much care where -" said Alice.  
@@ -84,5 +86,6 @@ Add some custom CSS to make your cookie clicker beautiful.
 ― Lewis Carroll, Alice in Wonderland  
 
 You're on the right path, so let's keep on walking.
+</blockquote>
 
 By completing this tutorial you should have some basic vanilla JavaScript DOM manipulation skills that will serve you handy in future projects.


### PR DESCRIPTION
You're quoting a block of Lewis Carrol, might as well use a block quote! 

I would do this anywhere else. Mark down uses `>` to generate block quote. The Make School markdown uses this differently. We may want to use `<blockquote>` instead. 

You may want to to do this for the earlier Lewis Carrol quote. It didn't occur to me at the time I read that one.